### PR TITLE
make the collection reader thread safe

### DIFF
--- a/api/src/main/scala-2.13+/LowPriorityBSONHandlerCompat.scala
+++ b/api/src/main/scala-2.13+/LowPriorityBSONHandlerCompat.scala
@@ -5,6 +5,15 @@ import scala.collection.Factory
 private[bson] trait LowPriorityBSONHandlersCompat {
   self: LowPriority1BSONHandlers =>
 
-  implicit final def collectionReader[M[_], T](implicit f: Factory[T, M[T]], reader: BSONReader[T]): BSONReader[M[T]] = new BSONArrayCollectionReader(() => f.newBuilder)
+  implicit final def collectionReader[M[_], T](
+    implicit
+    f: Factory[T, M[T]],
+    reader: BSONReader[T]): BSONReader[M[T]] = {
+    @inline def r = reader
+    new BSONArrayCollectionReader[M, T] {
+      val reader = r
+      def builder() = f.newBuilder
+    }
+  }
 
 }

--- a/api/src/main/scala-2.13+/LowPriorityBSONHandlerCompat.scala
+++ b/api/src/main/scala-2.13+/LowPriorityBSONHandlerCompat.scala
@@ -5,6 +5,6 @@ import scala.collection.Factory
 private[bson] trait LowPriorityBSONHandlersCompat {
   self: LowPriority1BSONHandlers =>
 
-  implicit final def collectionReader[M[_], T](implicit f: Factory[T, M[T]], reader: BSONReader[T]): BSONReader[M[T]] = new BSONArrayCollectionReader(f.newBuilder)
+  implicit final def collectionReader[M[_], T](implicit f: Factory[T, M[T]], reader: BSONReader[T]): BSONReader[M[T]] = new BSONArrayCollectionReader(() => f.newBuilder)
 
 }

--- a/api/src/main/scala-2.13-/LowPriorityBSONHandlerCompat.scala
+++ b/api/src/main/scala-2.13-/LowPriorityBSONHandlerCompat.scala
@@ -7,6 +7,6 @@ import scala.collection.generic.CanBuildFrom
 private[bson] trait LowPriorityBSONHandlersCompat {
   self: LowPriority1BSONHandlers =>
 
-  implicit final def collectionReader[M[_], T](implicit cbf: CanBuildFrom[M[_], T, M[T]], reader: BSONReader[T]): BSONReader[M[T]] = new BSONArrayCollectionReader(cbf())
+  implicit final def collectionReader[M[_], T](implicit cbf: CanBuildFrom[M[_], T, M[T]], reader: BSONReader[T]): BSONReader[M[T]] = new BSONArrayCollectionReader(cbf.apply _)
 
 }

--- a/api/src/main/scala-2.13-/LowPriorityBSONHandlerCompat.scala
+++ b/api/src/main/scala-2.13-/LowPriorityBSONHandlerCompat.scala
@@ -7,6 +7,14 @@ import scala.collection.generic.CanBuildFrom
 private[bson] trait LowPriorityBSONHandlersCompat {
   self: LowPriority1BSONHandlers =>
 
-  implicit final def collectionReader[M[_], T](implicit cbf: CanBuildFrom[M[_], T, M[T]], reader: BSONReader[T]): BSONReader[M[T]] = new BSONArrayCollectionReader(cbf.apply _)
-
+  implicit final def collectionReader[M[_], T](
+    implicit
+    cbf: CanBuildFrom[M[_], T, M[T]],
+    reader: BSONReader[T]): BSONReader[M[T]] = {
+    @inline def r = reader
+    new BSONArrayCollectionReader[M, T] {
+      val reader = r
+      def builder() = cbf()
+    }
+  }
 }

--- a/api/src/main/scala/DefaultBSONHandlers.scala
+++ b/api/src/main/scala/DefaultBSONHandlers.scala
@@ -263,9 +263,11 @@ private[bson] trait LowPriority1BSONHandlers
   implicit def collectionWriter[T, Repr <% Iterable[T]](implicit writer: BSONWriter[T], notOption: Repr ¬ Option[T]): BSONWriter[Repr] = new BSONArrayCollectionWriter[T, Repr]
 
   protected class BSONArrayCollectionReader[M[_], T](
-    builder: Builder[T, M[T]])(implicit reader: BSONReader[T]) extends BSONReader[M[T]] {
+    makeBuilder: () => Builder[T, M[T]])(implicit reader: BSONReader[T]) extends BSONReader[M[T]] {
 
     def readTry(bson: BSONValue): Try[M[T]] = {
+      val builder = makeBuilder()
+
       @annotation.tailrec
       def read(vs: Seq[BSONValue]): Try[M[T]] = vs.headOption match {
         case Some(v) => reader.readTry(v) match {


### PR DESCRIPTION
If a collection reader is reused,
then the builder endlessly accumulates past values,
leading to undesirable behaviour.

A solution would be to clear the buffer after use,
but the reader would still not be thread safe.

Thread safety can be achieved by instanciating
the buffer on demand