### PR TITLE
Avoid using a `MappedValues` view for Scala < 2.13

### DIFF
--- a/api/src/main/scala-2.13-/TypesCompat.scala
+++ b/api/src/main/scala-2.13-/TypesCompat.scala
@@ -10,5 +10,7 @@ private[bson] trait Utils {
 
   @inline private[bson] def toLazy[T](it: Traversable[T]) = it.toStream
 
-  @inline private[bson] def mapValues[K, V, U](m: Map[K, V])(f: V => U): Map[K, U] = m.mapValues(f)
+  @inline private[bson] def mapValues[K, V, U](m: Map[K, V])(f: V => U): Map[K, U] = m.transform {
+    case (_, v) => f(v)
+  }
 }

--- a/api/src/test/scala/HandlerSpec.scala
+++ b/api/src/test/scala/HandlerSpec.scala
@@ -219,6 +219,15 @@ final class HandlerSpec extends org.specs2.mutable.Specification {
 
         handler.readTry(input) must beSuccessfulTry(expectedResult)
       }
+
+      "fail" in {
+        val input = BSONDocument(
+          "a" -> BSONDocument("label" -> "foo", "count" -> 10),
+          "b" -> BSONDocument("wrong" -> "foo2"))
+        val handler = implicitly[BSONReader[Map[String, Foo]]]
+
+        handler.readTry(input) must beFailedTry
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #86.