### PR TITLE
[msb-compat] Fix `BsonInvalidOperationException` when current type not read

### DIFF
--- a/msb-compat/src/main/scala/HandlerConverters.scala
+++ b/msb-compat/src/main/scala/HandlerConverters.scala
@@ -199,7 +199,7 @@ private[msb] sealed trait BSONDecoder[T] extends Decoder[T] {
   protected def codecReg: CodecRegistry
 
   def decode(reader: BsonReader, ctx: DecoderContext): T = {
-    val v: BSONValue = reader.getCurrentBsonType match {
+    val v: BSONValue = Option(reader.getCurrentBsonType).getOrElse(reader.readBsonType) match {
       case BsonType.ARRAY =>
         ValueConverters.toArray(
           codecReg.get(classOf[BsonArray]).decode(reader, ctx))

--- a/msb-compat/src/main/scala/HandlerConverters.scala
+++ b/msb-compat/src/main/scala/HandlerConverters.scala
@@ -199,7 +199,15 @@ private[msb] sealed trait BSONDecoder[T] extends Decoder[T] {
   protected def codecReg: CodecRegistry
 
   def decode(reader: BsonReader, ctx: DecoderContext): T = {
-    val v: BSONValue = Option(reader.getCurrentBsonType).getOrElse(reader.readBsonType) match {
+    val current = reader.getCurrentBsonType
+
+    @SuppressWarnings(Array("NullParameter"))
+    def resolved = {
+      if (current != null) current
+      else reader.readBsonType()
+    }
+
+    val v: BSONValue = resolved match {
       case BsonType.ARRAY =>
         ValueConverters.toArray(
           codecReg.get(classOf[BsonArray]).decode(reader, ctx))

--- a/msb-compat/src/test/scala/HandlerConverterSpec.scala
+++ b/msb-compat/src/test/scala/HandlerConverterSpec.scala
@@ -25,7 +25,9 @@ import org.bson.{
 
 import org.bson.codecs._
 import org.bson.codecs.configuration.CodecRegistry
+import org.bson.json.JsonReader
 
+import reactivemongo.api.bson.BSONHandler
 import reactivemongo.api.bson.msb.HandlerConverters
 
 import org.specs2.specification.core.Fragment
@@ -65,6 +67,22 @@ final class HandlerConverterSpec
       case (cls, codec) => s"be resolved for ${cls.getSimpleName}" in {
         codecReg.get(cls).getClass must_== codec.getClass
       }
+    }
+  }
+
+  "Codec from Handler" should {
+    "not fail for simple types" in {
+      import HandlerConverters.DefaultCodecRegistry
+
+      val handler = implicitly[BSONHandler[Long]]
+      val codec = HandlerConverters.fromHandler(handler)
+
+      // https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson.Int64
+      val reader = new JsonReader("""{ "$numberLong": "42" }""")
+
+      val longValue = codec.decode(reader, DecoderContext.builder().build())
+
+      longValue === 42L
     }
   }
 }


### PR DESCRIPTION
A `BsonReader` maintains the current Bson type it has read. But it returns
`null` if the type was not yet read. The user must ensure to first call
`readBsonType` prior to calling `getCurrentBsonType`.

```
org.bson.BsonInvalidOperationException: readUndefined can only be called when CurrentBSONType is UNDEFINED, not when CurrentBSONType is
INT64. (AbstractBsonReader.java:690)
  org.bson.AbstractBsonReader.verifyBSONType(AbstractBsonReader.java:690)
  org.bson.AbstractBsonReader.checkPreconditions(AbstractBsonReader.java:722)
  org.bson.AbstractBsonReader.readUndefined(AbstractBsonReader.java:478)
  reactivemongo.api.bson.msb.BSONDecoder.decode(HandlerConverters.scala:271)
  reactivemongo.api.bson.msb.BSONDecoder.decode$(HandlerConverters.scala:201)
  reactivemongo.api.bson.msb.HandlerConverters$DefaultCodec.decode(HandlerConverters.scala:137)
  reactivemongo.HandlerConverterSpec.$anonfun$new$7(HandlerConverterSpec.scala:83)
```