### PR TITLE
Build msb-compat library for Scala 2.13

### DIFF
--- a/api/src/main/scala/package.scala
+++ b/api/src/main/scala/package.scala
@@ -76,6 +76,18 @@ package object bson extends DefaultBSONHandlers with Aliases with Utils {
    */
   def array(values: Producer[BSONValue]*) = BSONArray(values: _*)
 
+  /** Returns a BSON MinKey value */
+  def minKey: BSONMinKey = BSONMinKey
+
+  /** Returns a BSON MaxKey value */
+  def maxKey: BSONMaxKey = BSONMaxKey
+
+  /** Returns a BSON Null value */
+  def `null`: BSONNull = BSONNull
+
+  /** Returns a BSON Undefined value */
+  def undefined: BSONUndefined = BSONUndefined
+
   /** Returns a newly generated object ID. */
   def generateId = BSONObjectID.generate()
 

--- a/build.sbt
+++ b/build.sbt
@@ -107,18 +107,7 @@ lazy val msbCompat = (project in file("msb-compat")).settings(
   commonSettings ++ Seq(
     name := s"${baseArtifact}-msb-compat",
     description := "Compatibility library with mongo-scala-bson",
-    sourceDirectory := {
-      // mongo-scala-bson no available for 2.13
-      if (scalaBinaryVersion.value == "2.13") new java.io.File("/no/sources")
-      else sourceDirectory.value
-    },
-    libraryDependencies ++= {
-      if (scalaBinaryVersion.value != "2.13") {
-        Seq("org.mongodb.scala" %% "mongo-scala-bson" % "2.8.0" % Provided)
-      } else {
-        Seq.empty
-      }
-    },
+    libraryDependencies += "org.mongodb.scala" %% "mongo-scala-bson" % "2.8.0" % Provided,
     scalacOptions := (Def.taskDyn {
       val opts = scalacOptions.value
 

--- a/msb-compat/src/main/scala-2.13/JavaConverters.scala
+++ b/msb-compat/src/main/scala-2.13/JavaConverters.scala
@@ -1,0 +1,12 @@
+package reactivemongo.api.bson.msb
+
+import scala.jdk.CollectionConverters.{
+  SeqHasAsJava,
+  IterableHasAsScala
+}
+
+private[msb] object JavaConverters {
+  @inline def iterableAsScalaIterable[A](i: java.lang.Iterable[A]): Iterable[A] = IterableHasAsScala(i).asScala
+
+  @inline def seqAsJavaList[A](seq: Seq[A]): java.util.List[A] = SeqHasAsJava(seq).asJava
+}

--- a/msb-compat/src/test/scala/DecoderConverterSpec.scala
+++ b/msb-compat/src/test/scala/DecoderConverterSpec.scala
@@ -596,8 +596,8 @@ private[reactivemongo] trait DecoderConverterSpec {
         val codec: Codec[BSONMaxKey] = handler
         val dec: Decoder[BSONMaxKey] = reader
 
-        decode(new BsonMaxKey, dec) must beSuccessfulTry(BSONMaxKey) and {
-          decode(new BsonMaxKey, codec) must beSuccessfulTry(BSONMaxKey)
+        decode(new BsonMaxKey, dec) must beSuccessfulTry[BSONValue](BSONMaxKey) and {
+          decode(new BsonMaxKey, codec) must beSuccessfulTry[BSONValue](BSONMaxKey)
         }
       }
 
@@ -608,8 +608,8 @@ private[reactivemongo] trait DecoderConverterSpec {
         val codec: Codec[BSONMinKey] = handler
         val dec: Decoder[BSONMinKey] = reader
 
-        decode(new BsonMinKey, dec) must beSuccessfulTry(BSONMinKey) and {
-          decode(new BsonMinKey, codec) must beSuccessfulTry(BSONMinKey)
+        decode(new BsonMinKey, dec) must beSuccessfulTry[BSONValue](BSONMinKey) and {
+          decode(new BsonMinKey, codec) must beSuccessfulTry[BSONValue](BSONMinKey)
         }
       }
 
@@ -620,8 +620,8 @@ private[reactivemongo] trait DecoderConverterSpec {
         val codec: Codec[BSONNull] = handler
         val dec: Decoder[BSONNull] = reader
 
-        decode(new BsonNull, dec) must beSuccessfulTry(BSONNull) and {
-          decode(new BsonNull, codec) must beSuccessfulTry(BSONNull)
+        decode(new BsonNull, dec) must beSuccessfulTry[BSONValue](BSONNull) and {
+          decode(new BsonNull, codec) must beSuccessfulTry[BSONValue](BSONNull)
         }
       }
 
@@ -696,8 +696,8 @@ private[reactivemongo] trait DecoderConverterSpec {
         val codec: Codec[BSONUndefined] = handler
         val dec: Decoder[BSONUndefined] = reader
 
-        decode(new BsonUndefined, dec) must beSuccessfulTry(BSONUndefined) and {
-          decode(new BsonUndefined, codec) must beSuccessfulTry(BSONUndefined)
+        decode(new BsonUndefined, dec) must beSuccessfulTry[BSONValue](BSONUndefined) and {
+          decode(new BsonUndefined, codec) must beSuccessfulTry[BSONValue](BSONUndefined)
         }
       }
 

--- a/msb-compat/src/test/scala/DecoderConverterSpec.scala
+++ b/msb-compat/src/test/scala/DecoderConverterSpec.scala
@@ -54,7 +54,11 @@ import reactivemongo.api.bson.{
   BSONSymbol,
   BSONString,
   BSONTimestamp,
-  BSONUndefined
+  BSONUndefined,
+  minKey,
+  maxKey,
+  `null`,
+  undefined
 }
 import reactivemongo.api.bson.msb.HandlerConverters
 
@@ -294,8 +298,8 @@ private[reactivemongo] trait DecoderConverterSpec {
         val reader: BSONReader[BsonMaxKey] = dec
         val handler: BSONHandler[BsonMaxKey] = codec
 
-        reader.readTry(BSONMaxKey) must beSuccessfulTry(new BsonMaxKey) and {
-          handler.readTry(BSONMaxKey) must beSuccessfulTry(new BsonMaxKey)
+        reader.readTry(maxKey) must beSuccessfulTry(new BsonMaxKey) and {
+          handler.readTry(maxKey) must beSuccessfulTry(new BsonMaxKey)
         }
       }
 
@@ -306,8 +310,8 @@ private[reactivemongo] trait DecoderConverterSpec {
         val reader: BSONReader[BsonMinKey] = dec
         val handler: BSONHandler[BsonMinKey] = codec
 
-        reader.readTry(BSONMinKey) must beSuccessfulTry(new BsonMinKey) and {
-          handler.readTry(BSONMinKey) must beSuccessfulTry(new BsonMinKey)
+        reader.readTry(minKey) must beSuccessfulTry(new BsonMinKey) and {
+          handler.readTry(minKey) must beSuccessfulTry(new BsonMinKey)
         }
       }
 
@@ -318,8 +322,8 @@ private[reactivemongo] trait DecoderConverterSpec {
         val reader: BSONReader[BsonNull] = dec
         val handler: BSONHandler[BsonNull] = codec
 
-        reader.readTry(BSONNull) must beSuccessfulTry(new BsonNull) and {
-          handler.readTry(BSONNull) must beSuccessfulTry(new BsonNull)
+        reader.readTry(`null`) must beSuccessfulTry(new BsonNull) and {
+          handler.readTry(`null`) must beSuccessfulTry(new BsonNull)
         }
       }
 
@@ -395,9 +399,9 @@ private[reactivemongo] trait DecoderConverterSpec {
         val reader: BSONReader[BsonUndefined] = dec
         val handler: BSONHandler[BsonUndefined] = codec
 
-        reader.readTry(BSONUndefined).
+        reader.readTry(undefined).
           aka("undefined1") must beSuccessfulTry(new BsonUndefined) and {
-            handler.readTry(BSONUndefined).
+            handler.readTry(undefined).
               aka("undefined2") must beSuccessfulTry(new BsonUndefined)
           }
       }
@@ -596,8 +600,8 @@ private[reactivemongo] trait DecoderConverterSpec {
         val codec: Codec[BSONMaxKey] = handler
         val dec: Decoder[BSONMaxKey] = reader
 
-        decode(new BsonMaxKey, dec) must beSuccessfulTry[BSONValue](BSONMaxKey) and {
-          decode(new BsonMaxKey, codec) must beSuccessfulTry[BSONValue](BSONMaxKey)
+        decode(new BsonMaxKey, dec) must beSuccessfulTry(maxKey) and {
+          decode(new BsonMaxKey, codec) must beSuccessfulTry(maxKey)
         }
       }
 
@@ -608,8 +612,8 @@ private[reactivemongo] trait DecoderConverterSpec {
         val codec: Codec[BSONMinKey] = handler
         val dec: Decoder[BSONMinKey] = reader
 
-        decode(new BsonMinKey, dec) must beSuccessfulTry[BSONValue](BSONMinKey) and {
-          decode(new BsonMinKey, codec) must beSuccessfulTry[BSONValue](BSONMinKey)
+        decode(new BsonMinKey, dec) must beSuccessfulTry(minKey) and {
+          decode(new BsonMinKey, codec) must beSuccessfulTry(minKey)
         }
       }
 
@@ -620,8 +624,8 @@ private[reactivemongo] trait DecoderConverterSpec {
         val codec: Codec[BSONNull] = handler
         val dec: Decoder[BSONNull] = reader
 
-        decode(new BsonNull, dec) must beSuccessfulTry[BSONValue](BSONNull) and {
-          decode(new BsonNull, codec) must beSuccessfulTry[BSONValue](BSONNull)
+        decode(new BsonNull, dec) must beSuccessfulTry(`null`) and {
+          decode(new BsonNull, codec) must beSuccessfulTry(`null`)
         }
       }
 
@@ -696,8 +700,8 @@ private[reactivemongo] trait DecoderConverterSpec {
         val codec: Codec[BSONUndefined] = handler
         val dec: Decoder[BSONUndefined] = reader
 
-        decode(new BsonUndefined, dec) must beSuccessfulTry[BSONValue](BSONUndefined) and {
-          decode(new BsonUndefined, codec) must beSuccessfulTry[BSONValue](BSONUndefined)
+        decode(new BsonUndefined, dec) must beSuccessfulTry(undefined) and {
+          decode(new BsonUndefined, codec) must beSuccessfulTry(undefined)
         }
       }
 

--- a/msb-compat/src/test/scala/EncoderConverterSpec.scala
+++ b/msb-compat/src/test/scala/EncoderConverterSpec.scala
@@ -137,8 +137,8 @@ private[reactivemongo] trait EncoderConverterSpec {
 
         val bin = new BsonBinary(BsonBinarySubType.UUID_STANDARD, uuidBytes)
 
-        writer.writeTry(bin) must beSuccessfulTry(BSONBinary(uuid)) and {
-          handler.writeTry(bin) must beSuccessfulTry(BSONBinary(uuid))
+        writer.writeTry(bin) must beSuccessfulTry[BSONValue](BSONBinary(uuid)) and {
+          handler.writeTry(bin) must beSuccessfulTry[BSONValue](BSONBinary(uuid))
         }
       }
 
@@ -150,15 +150,15 @@ private[reactivemongo] trait EncoderConverterSpec {
         val handler: BSONHandler[BsonBoolean] = codec
 
         writer.writeTry(BsonBoolean.TRUE).
-          aka("true1") must beSuccessfulTry(BSONBoolean(true)) and {
+          aka("true1") must beSuccessfulTry[BSONValue](BSONBoolean(true)) and {
             writer.writeTry(BsonBoolean.FALSE).
-              aka("false1") must beSuccessfulTry(BSONBoolean(false))
+              aka("false1") must beSuccessfulTry[BSONValue](BSONBoolean(false))
           } and {
             handler.writeTry(BsonBoolean.FALSE).
-              aka("false2") must beSuccessfulTry(BSONBoolean(false))
+              aka("false2") must beSuccessfulTry[BSONValue](BSONBoolean(false))
           } and {
             handler.writeTry(BsonBoolean.TRUE).
-              aka("true2") must beSuccessfulTry(BSONBoolean(true))
+              aka("true2") must beSuccessfulTry[BSONValue](BSONBoolean(true))
           }
       }
 
@@ -183,8 +183,8 @@ private[reactivemongo] trait EncoderConverterSpec {
 
         val dec = new BsonDecimal128(Decimal128.POSITIVE_INFINITY)
 
-        writer.writeTry(dec) must beSuccessfulTry(BSONDecimal.PositiveInf) and {
-          handler.writeTry(dec) must beSuccessfulTry(BSONDecimal.PositiveInf)
+        writer.writeTry(dec) must beSuccessfulTry[BSONValue](BSONDecimal.PositiveInf) and {
+          handler.writeTry(dec) must beSuccessfulTry[BSONValue](BSONDecimal.PositiveInf)
         }
       }
 
@@ -195,8 +195,8 @@ private[reactivemongo] trait EncoderConverterSpec {
         val writer: BSONWriter[BsonDocument] = enc
         val handler: BSONWriter[BsonDocument] = codec
 
-        writer.writeTry(ldoc) must beSuccessfulTry(bdoc) and {
-          handler.writeTry(ldoc) must beSuccessfulTry(bdoc)
+        writer.writeTry(ldoc) must beSuccessfulTry[BSONValue](bdoc) and {
+          handler.writeTry(ldoc) must beSuccessfulTry[BSONValue](bdoc)
         }
       }
 
@@ -210,9 +210,9 @@ private[reactivemongo] trait EncoderConverterSpec {
         val raw = 3.4D
 
         writer.writeTry(new BsonDouble(raw)).
-          aka("double1") must beSuccessfulTry(BSONDouble(raw)) and {
+          aka("double1") must beSuccessfulTry[BSONValue](BSONDouble(raw)) and {
             handler.writeTry(new BsonDouble(raw)).
-              aka("double2") must beSuccessfulTry(BSONDouble(raw))
+              aka("double2") must beSuccessfulTry[BSONValue](BSONDouble(raw))
           }
       }
 
@@ -226,9 +226,9 @@ private[reactivemongo] trait EncoderConverterSpec {
         val raw = 45
 
         writer.writeTry(new BsonInt32(raw)).
-          aka("BSONValue1") must beSuccessfulTry(BSONInteger(raw)) and {
+          aka("BSONValue1") must beSuccessfulTry[BSONValue](BSONInteger(raw)) and {
             handler.writeTry(new BsonInt32(raw)).
-              aka("BSONValue2") must beSuccessfulTry(BSONInteger(raw))
+              aka("BSONValue2") must beSuccessfulTry[BSONValue](BSONInteger(raw))
           }
       }
 
@@ -242,9 +242,9 @@ private[reactivemongo] trait EncoderConverterSpec {
         val raw = 678L
 
         writer.writeTry(new BsonInt64(raw)).
-          aka("BSONLong1") must beSuccessfulTry(BSONLong(raw)) and {
+          aka("BSONLong1") must beSuccessfulTry[BSONValue](BSONLong(raw)) and {
             handler.writeTry(new BsonInt64(raw)).
-              aka("BSONLong2") must beSuccessfulTry(BSONLong(raw))
+              aka("BSONLong2") must beSuccessfulTry[BSONValue](BSONLong(raw))
           }
       }
 
@@ -258,9 +258,9 @@ private[reactivemongo] trait EncoderConverterSpec {
         val raw = "foo()"
 
         writer.writeTry(new BsonJavaScript(raw)).
-          aka("BSONJavaScript1") must beSuccessfulTry(BSONJavaScript(raw)) and {
+          aka("BSONJavaScript1") must beSuccessfulTry[BSONValue](BSONJavaScript(raw)) and {
             handler.writeTry(new BsonJavaScript(raw)).
-              aka("BSONJavaScript2") must beSuccessfulTry(BSONJavaScript(raw))
+              aka("BSONJavaScript2") must beSuccessfulTry[BSONValue](BSONJavaScript(raw))
           }
       }
 
@@ -277,10 +277,10 @@ private[reactivemongo] trait EncoderConverterSpec {
         val scope = new BsonDocument().append("lorem", new BsonInt64(2L))
 
         writer.writeTry(new BsonJavaScriptWithScope(code, scope)).
-          aka("BSONJavaScriptWS1") must beSuccessfulTry(
+          aka("BSONJavaScriptWS1") must beSuccessfulTry[BSONValue](
             BSONJavaScriptWS(code, BSONDocument("lorem" -> 2L))) and {
               handler.writeTry(new BsonJavaScriptWithScope(code, scope)).
-                aka("BSONJavaScriptWS2") must beSuccessfulTry(
+                aka("BSONJavaScriptWS2") must beSuccessfulTry[BSONValue](
                   BSONJavaScriptWS(code, BSONDocument("lorem" -> 2L)))
             }
       }
@@ -292,8 +292,8 @@ private[reactivemongo] trait EncoderConverterSpec {
         val writer: BSONWriter[BsonMaxKey] = enc
         val handler: BSONHandler[BsonMaxKey] = codec
 
-        writer.writeTry(new BsonMaxKey) must beSuccessfulTry(BSONMaxKey) and {
-          handler.writeTry(new BsonMaxKey) must beSuccessfulTry(BSONMaxKey)
+        writer.writeTry(new BsonMaxKey) must beSuccessfulTry[BSONValue](BSONMaxKey) and {
+          handler.writeTry(new BsonMaxKey) must beSuccessfulTry[BSONValue](BSONMaxKey)
         }
       }
 
@@ -304,8 +304,8 @@ private[reactivemongo] trait EncoderConverterSpec {
         val writer: BSONWriter[BsonMinKey] = enc
         val handler: BSONHandler[BsonMinKey] = codec
 
-        writer.writeTry(new BsonMinKey) must beSuccessfulTry(BSONMinKey) and {
-          handler.writeTry(new BsonMinKey) must beSuccessfulTry(BSONMinKey)
+        writer.writeTry(new BsonMinKey) must beSuccessfulTry[BSONValue](BSONMinKey) and {
+          handler.writeTry(new BsonMinKey) must beSuccessfulTry[BSONValue](BSONMinKey)
         }
       }
 
@@ -316,8 +316,8 @@ private[reactivemongo] trait EncoderConverterSpec {
         val writer: BSONWriter[BsonNull] = enc
         val handler: BSONHandler[BsonNull] = codec
 
-        writer.writeTry(new BsonNull) must beSuccessfulTry(BSONNull) and {
-          handler.writeTry(new BsonNull) must beSuccessfulTry(BSONNull)
+        writer.writeTry(new BsonNull) must beSuccessfulTry[BSONValue](BSONNull) and {
+          handler.writeTry(new BsonNull) must beSuccessfulTry[BSONValue](BSONNull)
         }
       }
 
@@ -397,9 +397,9 @@ private[reactivemongo] trait EncoderConverterSpec {
         val handler: BSONHandler[BsonUndefined] = codec
 
         writer.writeTry(new BsonUndefined).
-          aka("undefined1") must beSuccessfulTry(BSONUndefined) and {
+          aka("undefined1") must beSuccessfulTry[BSONValue](BSONUndefined) and {
             handler.writeTry(new BsonUndefined).
-              aka("undefined2") must beSuccessfulTry(BSONUndefined)
+              aka("undefined2") must beSuccessfulTry[BSONValue](BSONUndefined)
           }
       }
 

--- a/msb-compat/src/test/scala/EncoderConverterSpec.scala
+++ b/msb-compat/src/test/scala/EncoderConverterSpec.scala
@@ -54,7 +54,11 @@ import reactivemongo.api.bson.{
   BSONString,
   BSONTimestamp,
   BSONUndefined,
-  BSONWriter
+  BSONWriter,
+  maxKey,
+  minKey,
+  `null`,
+  undefined
 }
 import reactivemongo.api.bson.msb.HandlerConverters
 
@@ -137,8 +141,8 @@ private[reactivemongo] trait EncoderConverterSpec {
 
         val bin = new BsonBinary(BsonBinarySubType.UUID_STANDARD, uuidBytes)
 
-        writer.writeTry(bin) must beSuccessfulTry[BSONValue](BSONBinary(uuid)) and {
-          handler.writeTry(bin) must beSuccessfulTry[BSONValue](BSONBinary(uuid))
+        writer.writeTry(bin) must beSuccessfulTry(BSONBinary(uuid)) and {
+          handler.writeTry(bin) must beSuccessfulTry(BSONBinary(uuid))
         }
       }
 
@@ -150,15 +154,15 @@ private[reactivemongo] trait EncoderConverterSpec {
         val handler: BSONHandler[BsonBoolean] = codec
 
         writer.writeTry(BsonBoolean.TRUE).
-          aka("true1") must beSuccessfulTry[BSONValue](BSONBoolean(true)) and {
+          aka("true1") must beSuccessfulTry(BSONBoolean(true)) and {
             writer.writeTry(BsonBoolean.FALSE).
-              aka("false1") must beSuccessfulTry[BSONValue](BSONBoolean(false))
+              aka("false1") must beSuccessfulTry(BSONBoolean(false))
           } and {
             handler.writeTry(BsonBoolean.FALSE).
-              aka("false2") must beSuccessfulTry[BSONValue](BSONBoolean(false))
+              aka("false2") must beSuccessfulTry(BSONBoolean(false))
           } and {
             handler.writeTry(BsonBoolean.TRUE).
-              aka("true2") must beSuccessfulTry[BSONValue](BSONBoolean(true))
+              aka("true2") must beSuccessfulTry(BSONBoolean(true))
           }
       }
 
@@ -183,8 +187,8 @@ private[reactivemongo] trait EncoderConverterSpec {
 
         val dec = new BsonDecimal128(Decimal128.POSITIVE_INFINITY)
 
-        writer.writeTry(dec) must beSuccessfulTry[BSONValue](BSONDecimal.PositiveInf) and {
-          handler.writeTry(dec) must beSuccessfulTry[BSONValue](BSONDecimal.PositiveInf)
+        writer.writeTry(dec) must beSuccessfulTry(BSONDecimal.PositiveInf) and {
+          handler.writeTry(dec) must beSuccessfulTry(BSONDecimal.PositiveInf)
         }
       }
 
@@ -195,8 +199,8 @@ private[reactivemongo] trait EncoderConverterSpec {
         val writer: BSONWriter[BsonDocument] = enc
         val handler: BSONWriter[BsonDocument] = codec
 
-        writer.writeTry(ldoc) must beSuccessfulTry[BSONValue](bdoc) and {
-          handler.writeTry(ldoc) must beSuccessfulTry[BSONValue](bdoc)
+        writer.writeTry(ldoc) must beSuccessfulTry(bdoc) and {
+          handler.writeTry(ldoc) must beSuccessfulTry(bdoc)
         }
       }
 
@@ -210,9 +214,9 @@ private[reactivemongo] trait EncoderConverterSpec {
         val raw = 3.4D
 
         writer.writeTry(new BsonDouble(raw)).
-          aka("double1") must beSuccessfulTry[BSONValue](BSONDouble(raw)) and {
+          aka("double1") must beSuccessfulTry(BSONDouble(raw)) and {
             handler.writeTry(new BsonDouble(raw)).
-              aka("double2") must beSuccessfulTry[BSONValue](BSONDouble(raw))
+              aka("double2") must beSuccessfulTry(BSONDouble(raw))
           }
       }
 
@@ -226,9 +230,9 @@ private[reactivemongo] trait EncoderConverterSpec {
         val raw = 45
 
         writer.writeTry(new BsonInt32(raw)).
-          aka("BSONValue1") must beSuccessfulTry[BSONValue](BSONInteger(raw)) and {
+          aka("BSONValue1") must beSuccessfulTry(BSONInteger(raw)) and {
             handler.writeTry(new BsonInt32(raw)).
-              aka("BSONValue2") must beSuccessfulTry[BSONValue](BSONInteger(raw))
+              aka("BSONValue2") must beSuccessfulTry(BSONInteger(raw))
           }
       }
 
@@ -242,9 +246,9 @@ private[reactivemongo] trait EncoderConverterSpec {
         val raw = 678L
 
         writer.writeTry(new BsonInt64(raw)).
-          aka("BSONLong1") must beSuccessfulTry[BSONValue](BSONLong(raw)) and {
+          aka("BSONLong1") must beSuccessfulTry(BSONLong(raw)) and {
             handler.writeTry(new BsonInt64(raw)).
-              aka("BSONLong2") must beSuccessfulTry[BSONValue](BSONLong(raw))
+              aka("BSONLong2") must beSuccessfulTry(BSONLong(raw))
           }
       }
 
@@ -258,9 +262,9 @@ private[reactivemongo] trait EncoderConverterSpec {
         val raw = "foo()"
 
         writer.writeTry(new BsonJavaScript(raw)).
-          aka("BSONJavaScript1") must beSuccessfulTry[BSONValue](BSONJavaScript(raw)) and {
+          aka("BSONJavaScript1") must beSuccessfulTry(BSONJavaScript(raw)) and {
             handler.writeTry(new BsonJavaScript(raw)).
-              aka("BSONJavaScript2") must beSuccessfulTry[BSONValue](BSONJavaScript(raw))
+              aka("BSONJavaScript2") must beSuccessfulTry(BSONJavaScript(raw))
           }
       }
 
@@ -277,10 +281,10 @@ private[reactivemongo] trait EncoderConverterSpec {
         val scope = new BsonDocument().append("lorem", new BsonInt64(2L))
 
         writer.writeTry(new BsonJavaScriptWithScope(code, scope)).
-          aka("BSONJavaScriptWS1") must beSuccessfulTry[BSONValue](
+          aka("BSONJavaScriptWS1") must beSuccessfulTry(
             BSONJavaScriptWS(code, BSONDocument("lorem" -> 2L))) and {
               handler.writeTry(new BsonJavaScriptWithScope(code, scope)).
-                aka("BSONJavaScriptWS2") must beSuccessfulTry[BSONValue](
+                aka("BSONJavaScriptWS2") must beSuccessfulTry(
                   BSONJavaScriptWS(code, BSONDocument("lorem" -> 2L)))
             }
       }
@@ -292,8 +296,8 @@ private[reactivemongo] trait EncoderConverterSpec {
         val writer: BSONWriter[BsonMaxKey] = enc
         val handler: BSONHandler[BsonMaxKey] = codec
 
-        writer.writeTry(new BsonMaxKey) must beSuccessfulTry[BSONValue](BSONMaxKey) and {
-          handler.writeTry(new BsonMaxKey) must beSuccessfulTry[BSONValue](BSONMaxKey)
+        writer.writeTry(new BsonMaxKey) must beSuccessfulTry(maxKey) and {
+          handler.writeTry(new BsonMaxKey) must beSuccessfulTry(maxKey)
         }
       }
 
@@ -304,8 +308,8 @@ private[reactivemongo] trait EncoderConverterSpec {
         val writer: BSONWriter[BsonMinKey] = enc
         val handler: BSONHandler[BsonMinKey] = codec
 
-        writer.writeTry(new BsonMinKey) must beSuccessfulTry[BSONValue](BSONMinKey) and {
-          handler.writeTry(new BsonMinKey) must beSuccessfulTry[BSONValue](BSONMinKey)
+        writer.writeTry(new BsonMinKey) must beSuccessfulTry(minKey) and {
+          handler.writeTry(new BsonMinKey) must beSuccessfulTry(minKey)
         }
       }
 
@@ -316,8 +320,8 @@ private[reactivemongo] trait EncoderConverterSpec {
         val writer: BSONWriter[BsonNull] = enc
         val handler: BSONHandler[BsonNull] = codec
 
-        writer.writeTry(new BsonNull) must beSuccessfulTry[BSONValue](BSONNull) and {
-          handler.writeTry(new BsonNull) must beSuccessfulTry[BSONValue](BSONNull)
+        writer.writeTry(new BsonNull) must beSuccessfulTry(`null`) and {
+          handler.writeTry(new BsonNull) must beSuccessfulTry(`null`)
         }
       }
 
@@ -397,9 +401,9 @@ private[reactivemongo] trait EncoderConverterSpec {
         val handler: BSONHandler[BsonUndefined] = codec
 
         writer.writeTry(new BsonUndefined).
-          aka("undefined1") must beSuccessfulTry[BSONValue](BSONUndefined) and {
+          aka("undefined1") must beSuccessfulTry(undefined) and {
             handler.writeTry(new BsonUndefined).
-              aka("undefined2") must beSuccessfulTry[BSONValue](BSONUndefined)
+              aka("undefined2") must beSuccessfulTry(undefined)
           }
       }
 


### PR DESCRIPTION
* mongo-scala-bson has been released for Scala 2.13 quite some while ago