### PR TITLE
BSONObjectID should fail gracefully with non-hex 24 character strings.

### DIFF
--- a/api/src/main/scala/types.scala
+++ b/api/src/main/scala/types.scala
@@ -980,7 +980,13 @@ object BSONObjectID {
   def parse(id: String): Try[BSONObjectID] = {
     if (id.length != 24) Failure[BSONObjectID](
       new IllegalArgumentException(s"Wrong ObjectId (length != 24): '$id'"))
-    else parse(Digest str2Hex id)
+    else for {
+      bytes <- Try(Digest str2Hex id) match {
+        case Failure(_: NumberFormatException) => Failure(new IllegalArgumentException(s"'$id' is not a valid hex string'"))
+        case t => t
+      }
+      res <- parse(bytes)
+    } yield res
   }
 
   /** Tries to make a BSON ObjectId from a binary representation. */

--- a/api/src/main/scala/types.scala
+++ b/api/src/main/scala/types.scala
@@ -980,13 +980,12 @@ object BSONObjectID {
   def parse(id: String): Try[BSONObjectID] = {
     if (id.length != 24) Failure[BSONObjectID](
       new IllegalArgumentException(s"Wrong ObjectId (length != 24): '$id'"))
-    else for {
-      bytes <- Try(Digest str2Hex id) match {
-        case Failure(_: NumberFormatException) => Failure(new IllegalArgumentException(s"'$id' is not a valid hex string'"))
-        case t => t
-      }
-      res <- parse(bytes)
-    } yield res
+    else try {
+      Success(parse(Digest str2Hex id))
+    } catch {
+      case NonFatal(cause) => 
+        Failure(new IllegalArgumentException(s"Wrong ObjectId (not a valid hex string): '$id'", cause))
+    }
   }
 
   /** Tries to make a BSON ObjectId from a binary representation. */

--- a/api/src/main/scala/types.scala
+++ b/api/src/main/scala/types.scala
@@ -981,7 +981,7 @@ object BSONObjectID {
     if (id.length != 24) Failure[BSONObjectID](
       new IllegalArgumentException(s"Wrong ObjectId (length != 24): '$id'"))
     else try {
-      Success(parse(Digest str2Hex id))
+      parse(Digest str2Hex id)
     } catch {
       case NonFatal(cause) =>
         Failure(new IllegalArgumentException(s"Wrong ObjectId (not a valid hex string): '$id'", cause))

--- a/api/src/main/scala/types.scala
+++ b/api/src/main/scala/types.scala
@@ -983,7 +983,7 @@ object BSONObjectID {
     else try {
       Success(parse(Digest str2Hex id))
     } catch {
-      case NonFatal(cause) => 
+      case NonFatal(cause) =>
         Failure(new IllegalArgumentException(s"Wrong ObjectId (not a valid hex string): '$id'", cause))
     }
   }

--- a/api/src/test/scala/BSONObjectIDSpec.scala
+++ b/api/src/test/scala/BSONObjectIDSpec.scala
@@ -38,6 +38,12 @@ final class BSONObjectIDSpec extends org.specs2.mutable.Specification {
           case nextObjectID => objectID must not(beTypedEqualTo(nextObjectID))
         }
     }
+
+    "fail gracefully for illegal 24 character strings" in {
+      val shouldFail = List.fill(24)("z").mkString("")
+
+      BSONObjectID.parse(shouldFail) must beAFailedTry[BSONObjectID].withThrowable[IllegalArgumentException]
+    }
   }
 
   "Digest" should {


### PR DESCRIPTION
Currently, if attempting to parse a string as bson, if the string is 24 characters long and _not_ a valid hex string, it will _throw_ a `NumberFormatException`, rather than safely capture the failure in a `Try`. This was due to `Digest.str2hex` throwing that exception, and not being called within a `Try` block.

This wraps the call in a `Try`, and converts the `NumberFormatException` to an `IllegalArgumentException`.