### PR TITLE
Fix BSONDocument `isEmpty` definition

### DIFF
--- a/api/src/main/scala/types.scala
+++ b/api/src/main/scala/types.scala
@@ -1947,7 +1947,7 @@ sealed abstract class BSONDocument
     val elements =
       (toLazy(self.elements) ++ toLazy(doc.elements)).distinct
 
-    @inline def headOption = self.headOption
+    @inline def headOption = elements.headOption
     val isEmpty = self.isEmpty && doc.isEmpty
   }
 
@@ -1984,7 +1984,7 @@ sealed abstract class BSONDocument
       m.toMap
     }
 
-    @inline def headOption = self.headOption
+    @inline def headOption = elements.headOption
     val isEmpty = self.isEmpty && seq.isEmpty
   }
 
@@ -2294,8 +2294,8 @@ private[bson] sealed trait BSONDocumentLowPriority { self: BSONDocument =>
 
     lazy val fields = BSONDocument.toMap(elements)
 
-    val isEmpty = self.elements.isEmpty && producers.isEmpty
-    @inline def headOption = self.elements.headOption
+    def isEmpty = headOption.isEmpty
+    @inline def headOption = elements.headOption
   }
 }
 
@@ -2392,8 +2392,8 @@ private[bson] sealed trait BSONStrictDocumentLowPriority {
 
       lazy val fields = BSONDocument.toMap(elements)
 
-      val isEmpty = self.elements.isEmpty && producers.isEmpty
-      @inline def headOption = self.elements.headOption
+      def isEmpty = headOption.isEmpty
+      @inline def headOption = elements.headOption
     }
 }
 
@@ -2439,7 +2439,7 @@ object BSONDocument {
   def apply(elms: ElementProducer*): BSONDocument = new BSONDocument {
     val elements = toLazy(elms).distinct.flatMap(_.generate())
     lazy val fields = BSONDocument.toMap(elms)
-    val isEmpty = elms.isEmpty
+    def isEmpty = headOption.isEmpty
     @inline def headOption = elements.headOption
   }
 
@@ -2529,7 +2529,7 @@ object BSONDocument {
     new BSONDocument with BSONStrictDocument {
       val elements = dedupProducers(toLazy(elms))
       lazy val fields = BSONDocument.toMap(elements)
-      val isEmpty = elms.isEmpty
+      def isEmpty = headOption.isEmpty
       @inline def headOption = elements.headOption
     }
 

--- a/api/src/test/scala/BSONDocumentSpec.scala
+++ b/api/src/test/scala/BSONDocumentSpec.scala
@@ -1,4 +1,4 @@
-import reactivemongo.api.bson._
+import reactivemongo.api.bson.{ BSONDocument, _ }
 
 final class BSONDocumentSpec extends org.specs2.mutable.Specification {
   "BSONDocument" title
@@ -13,14 +13,88 @@ final class BSONDocumentSpec extends org.specs2.mutable.Specification {
         document().elements must beEmpty
       } and {
         BSONDocument.empty.contains("foo") must beFalse
+      } and {
+        val doc = BSONDocument("foo" -> Option.empty[Int])
+        doc.elements must_== Seq.empty[BSONElement]
+        doc.isEmpty must beTrue
+      } and {
+        val doc = BSONDocument("foo" -> Option.empty[Int], "bar" -> Option.empty[Int])
+        doc.elements must_== Seq.empty[BSONElement]
+        doc.isEmpty must beTrue
+      } and {
+        val doc = BSONDocument.empty ++ BSONDocument("foo" -> Option.empty[Int])
+        doc.elements must_== Seq.empty[BSONElement]
+        doc.isEmpty must beTrue
+      } and {
+        val doc = BSONDocument.empty ++ BSONDocument("foo" -> Option.empty[Int], "bar" -> Option.empty[Int])
+        doc.elements must_== Seq.empty[BSONElement]
+        doc.isEmpty must beTrue
+      } /*and {
+        /*
+        Casting error:
+        java.lang.ClassCastException: class reactivemongo.api.bson.ElementProducer$Empty$ cannot be cast to
+        class reactivemongo.api.bson.BSONElement (reactivemongo.api.bson.ElementProducer$Empty$ and reactivemongo.api.bson.BSONElement
+        are in unnamed module of loader 'app')
+
+        incorrect variant ++(BSONElement*), gets invoked (correct one ++(ElementProducers*))
+         */
+        val p: ElementProducer = BSONElement("foo", Option.empty[Int])
+        val doc = BSONDocument.empty ++ p
+        doc.elements must_== Seq.empty[BSONElement]
+        doc.isEmpty must beTrue
+      } and {
+        /*
+        Casting error:
+        java.lang.ClassCastException: class reactivemongo.api.bson.ElementProducer$Empty$ cannot be cast to
+        class reactivemongo.api.bson.BSONElement (reactivemongo.api.bson.ElementProducer$Empty$ and reactivemongo.api.bson.BSONElement
+        are in unnamed module of loader 'app')
+
+        incorrect variant ++(BSONElement*), gets invoked (correct one ++(ElementProducers*))
+         */
+        val doc = BSONDocument.empty ++ ("foo" -> Option.empty[Int])
+        println {
+          doc.elements.head // ClassCastException
+        }
+        doc.elements must_== Seq.empty[BSONElement]
+        doc.isEmpty must beTrue
+      }*/
+    }
+
+    "be appended with a new tuple " in {
+      val ep: ElementProducer = ("foo" -> 1)
+      val doc = BSONDocument.empty ++ ep
+
+      (doc must_=== BSONDocument("foo" -> 1)) and {
+        doc.contains("foo") must beTrue
+      } and {
+        doc.headOption must beSome
+      } and {
+        doc.isEmpty must beFalse
       }
     }
 
     "be appended with a new element " in {
-      val doc = BSONDocument.empty ++ ("foo" -> 1)
+      val doc = BSONDocument.empty ++ BSONElement("foo", BSONInteger(1))
 
-      doc must_=== BSONDocument("foo" -> 1) and (
-        doc.contains("foo") must beTrue)
+      (doc must_=== BSONDocument("foo" -> 1)) and {
+        doc.contains("foo") must beTrue
+      } and {
+        doc.headOption must beSome
+      } and {
+        doc.isEmpty must beFalse
+      }
+    }
+
+    "be appended with a new document " in {
+      val doc = BSONDocument.empty ++ BSONDocument("foo" -> 1)
+
+      (doc must_=== BSONDocument("foo" -> 1)) and {
+        doc.contains("foo") must beTrue
+      } and {
+        doc.headOption must beSome
+      } and {
+        doc.isEmpty must beFalse
+      }
     }
   }
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/ReactiveMongo/ReactiveMongo/blob/master/CONTRIBUTING.md#reactivemongo-developer--contributor-guidelines)?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #207

## Purpose

Fix BSONDocument implementations for isEmpty and headOption fields.